### PR TITLE
Improvements to Remote Setup and Connectivity articles

### DIFF
--- a/Advanced-Menu.md
+++ b/Advanced-Menu.md
@@ -55,7 +55,7 @@ If you're certain you've opened the port and are still unable to connect, the ne
 
 Emby Server also allows you to connect when away from home. We call these external connections because they're out of our home network. Before we begin, we'll assume everything covered above in the **In-Network Connections** section is functioning correctly with your Emby Server, and that you're able to connect using other devices in your home network. If not, then you'll want to go over that section first.
 
-From here, we suggest using the [Emby Connect](Emby-Connect.md) feature as it takes the guesswork out of external connectivity. You only need to read below if you're not using Emby Connect, or you're having trouble connecting.
+The [Remote Setup](Remote-Setup.md) article covers how remote access is enabled and the option for automatic port forwarding using the router's uPnP feature.
 
 ### Locate Your External Address
 
@@ -75,10 +75,15 @@ If the external address works in a browser, then you're good to go, and can proc
 
 If you're still unable to connect after testing the above, then you may need to setup port forwarding with your router to allow external connectivity to your Emby Server.
 
-To do this, you'll need to open the web interface for your router, and forward TCP Port 8096 on your router to port 8096 on the Emby Server machine.
+To do this, turn off the "Enable automatic port forwarding" option just set and open the web interface for your router. You will need to forward TCP Port 8096 on your router to port 8096 on the Emby Server machine. Do the same for port 8920 as well (if using SSL). It is important that the local IP Address for the Emby Server machine does not change. Use the router's DHCP Reservation feature to do that.
 
-The process of doing this will be slightly different for each router model.  Here is a good step by step guide on how to do this:
+If you want to use different public port numbers, see [Network (Hosting) Settings](Hosting-Settings.md).  If you have more than one Emby Server on your local network and the manual port forward method is required, then it will be necessary to change from using the default public port numbers, since each server must have a different public port number.
 
+If you have more than one router, eg an ISP provided router and also your own router, then that would lead to a Double NAT which would lead to failure to reach the server externally.  In such cases, it is recommended that one router, e.g. the ISP router, is configured to run in Modem/Bridge mode.  If they both need to be running as routers, the configuration would be more complex, needing to cascade the port forward for the public port from the first router to the second and have the actual required port forward on the 2nd router.  Also the 2nd router would need to have its local IP Address as a DHCP reservation on the first router.
+
+The process of doing the port forward will be slightly different for each router model.  Here are good step by step guides on how to do this:
+
+https://portforward.com/dhcp-reservation/#how-to-make-a-dhcp-reservation-in-your-router
 http://www.wikihow.com/Set-Up-Port-Forwarding-on-a-Router
 
 This Youtube video also explains it pretty well:
@@ -91,7 +96,11 @@ To test that your public port is accessible over the internet, try testing it fr
 
 If this test does not succeed, then it's an indication that your router is blocking the traffic and may need additional configuration.
 
+If the test succeeds but the device is not able to connect to the server externally, check that you have enabled remote connections for the user. See [Users](Users.md).
+
 ### Remote Access Configuration
-Check out the following link for in-depth instructions to set up remote access on Emby Server.
-![](https://emby.media/support/articles/Remote-Setup.md)
-https://github.com/EmbySupport/Emby.Docs/blob/master/Remote-Setup.md
+Check out the following link for in-depth instructions to set up remote access on Emby Server [Remote Setup](Remote-Setup.md).
+
+### Emby Connect
+
+Regardless of the method used for port forwarding, whether it is automatic using uPnP or a manual configuration of the router, we suggest using the Emby Connect feature as it takes the guesswork out of external connectivity. The Emby apps would find the route to the server using Emby Connect.  See [Emby Connect](Emby-Connect.md).

--- a/Connectivity.md
+++ b/Connectivity.md
@@ -55,7 +55,7 @@ If you're certain you've opened the port and are still unable to connect, the ne
 
 Emby Server also allows you to connect when away from home. We call these external connections because they're out of our home network. Before we begin, we'll assume everything covered above in the **In-Network Connections** section is functioning correctly with your Emby Server, and that you're able to connect using other devices in your home network. If not, then you'll want to go over that section first.
 
-From here, we suggest using the [Emby Connect](Emby-Connect.md) feature as it takes the guesswork out of external connectivity. You only need to read below if you're not using Emby Connect, or you're having trouble connecting.
+The [Remote Setup](Remote-Setup.md) article covers how remote access is enabled and the option for automatic port forwarding using the router's uPnP feature.
 
 ### Locate Your External Address
 
@@ -75,10 +75,15 @@ If the external address works in a browser, then you're good to go, and can proc
 
 If you're still unable to connect after testing the above, then you may need to setup port forwarding with your router to allow external connectivity to your Emby Server.
 
-To do this, you'll need to open the web interface for your router, and forward TCP Port 8096 on your router to port 8096 on the Emby Server machine.
+To do this, turn off the "Enable automatic port forwarding" option just set and open the web interface for your router. You will need to forward TCP Port 8096 on your router to port 8096 on the Emby Server machine. Do the same for port 8920 as well (if using SSL). It is important that the local IP Address for the Emby Server machine does not change. Use the router's DHCP Reservation feature to do that.
 
-The process of doing this will be slightly different for each router model.  Here is a good step by step guide on how to do this:
+If you want to use different public port numbers, see [Network (Hosting) Settings](Hosting-Settings.md).  If you have more than one Emby Server on your local network and the manual port forward method is required, then it will be necessary to change from using the default public port numbers, since each server must have a different public port number.
 
+If you have more than one router, eg an ISP provided router and also your own router, then that would lead to a Double NAT which would lead to failure to reach the server externally.  In such cases, it is recommended that one router, e.g. the ISP router, is configured to run in Modem/Bridge mode.  If they both need to be running as routers, the configuration would be more complex, needing to cascade the port forward for the public port from the first router to the second and have the actual required port forward on the 2nd router.  Also the 2nd router would need to have its local IP Address as a DHCP reservation on the first router.
+
+The process of doing the port forward will be slightly different for each router model.  Here are good step by step guides on how to do this:
+
+https://portforward.com/dhcp-reservation/#how-to-make-a-dhcp-reservation-in-your-router
 http://www.wikihow.com/Set-Up-Port-Forwarding-on-a-Router
 
 This Youtube video also explains it pretty well:
@@ -91,7 +96,11 @@ To test that your public port is accessible over the internet, try testing it fr
 
 If this test does not succeed, then it's an indication that your router is blocking the traffic and may need additional configuration.
 
+If the test succeeds but the device is not able to connect to the server externally, check that you have enabled remote connections for the user. See [Users](Users.md).
+
 ### Remote Access Configuration
-Check out the following link for in-depth instructions to set up remote access on Emby Server.
-![](https://emby.media/support/articles/Remote-Setup.md)
-https://github.com/EmbySupport/Emby.Docs/blob/master/Remote-Setup.md
+Check out the following link for in-depth instructions to set up remote access on Emby Server [Remote Setup](Remote-Setup.md).
+
+### Emby Connect
+
+Regardless of the method used for port forwarding, whether it is automatic using uPnP or a manual configuration of the router, we suggest using the Emby Connect feature as it takes the guesswork out of external connectivity. The Emby apps would find the route to the server using Emby Connect.  See [Emby Connect](Emby-Connect.md).

--- a/Remote-Setup.md
+++ b/Remote-Setup.md
@@ -12,7 +12,7 @@ If you have any issues with connections in your network check out local connecti
 
 ### Turn on Remote Access
 
-The first step is to enable remote access. You do this from the Server's Network menu by enabling "Allow remote connections to this Emby Server". 
+The first step is to enable remote access. You do this from the Server's Network menu by enabling "Allow remote connections to this Emby Server". Note that this also needs to be enabled at the user level - see paragraph at the bottom of this article.
 
 ![Remote Setup1](images/server/remote_setup1.png)
 
@@ -36,7 +36,11 @@ If you're unable to connect after testing the above settings with automatic port
 
 To do this, turn off the "Enable automatic port forwarding" option just set and open the web interface for your router. You will need to forward TCP Port 8096 on your router to port 8096 on the Emby Server machine. Do the same for port 8920 as well (if using SSL). It is important that the local IP Address for the Emby Server machine does not change. Use the router's DHCP Reservation feature to do that.
 
-The process of doing this will be slightly different for each router model. 
+If you want to use different public port numbers, see [Network (Hosting) Settings](Hosting-Settings.md).  If you have more than one Emby Server on your local network and the manual port forward method is required, then it will be necessary to change from using the default public port numbers, since each server must have a different public port number.
+
+If you have more than one router, eg an ISP provided router and also your own router, then that would lead to a Double NAT which would lead to failure to reach the server externally.  In such cases, it is recommended that one router, e.g. the ISP router, is configured to run in Modem/Bridge mode.  If they both need to be running as routers, the configuration would be more complex, needing to cascade the port forward for the public port from the first router to the second and have the actual required port forward on the 2nd router.  Also the 2nd router would need to have its local IP Address as a DHCP reservation on the first router.
+
+The process of doing a port forward will be slightly different for each router model. 
 
 - Here are good step by step guides on how to do this:
   https://portforward.com/dhcp-reservation/#how-to-make-a-dhcp-reservation-in-your-router
@@ -67,17 +71,25 @@ If this doesn't work continue with how to verify your public IP and port.
 
 ### Verify Public IP and Port
 
-To test these open a browser and visit [canyouseeme.org](http://example.com).  
+To test these open a browser and visit [canyouseeme.org](http://www.canyouseeme.org).  
 The IP you see listed here must match what Emby shows on the dashboard.  If it doesn't remote access will not work and likely your ISP is using CG-NAT and you are blocked from running services.  In this case visit our forums for assistance.
 
-If the IP address matches the next step is to enter the PORT (8096 or 8920) to test on [canyouseeme.org](http://example.com). If it succeeds your Emby Server should be working remotely.  If this test fails you should re-check the setup mentioned above. If you have any issues please visit our forums for assistance.
+If the IP address matches the next step is to enter the PORT (8096 or 8920) to test on [canyouseeme.org](http://www.canyouseeme.org). If it succeeds your Emby Server should be working remotely.  If this test fails you should re-check the setup mentioned above. If you have any issues please visit our forums for assistance.
 
 If this doesn't work you will want to try completely disabling (turn off) any local malware & firewall software running on the same host temporarily to see if they may be blocking Emby.
 
 If you have a VPN running on the host computer TURN THIS OFF as that may interfere with your Emby Server routing.
 
-You could also be blocked by your ISP in something known as a cgNAT (carrier grade Network Address Translation).  One way of spotting this is to open a command prompt and doing a trace route to 8.8.8.8.
+You could also be blocked by your ISP in something known as a cgNAT (carrier grade Network Address Translation).  To check if you have been given a cgNAT public IP Address, see if it is within this IP range 100.64.0.0 - 100.127.255.255. The is the range for cgNAT. If this is the case, you would need to ask the ISP to give you a static public IP address outside this range. There is normally a monthly fee for this.  One way of spotting if the ISP is blocking the connection, is to open a command prompt and doing a trace route to 8.8.8.8.
 
 On windows it would be: `tracert 8.8.8.8`
 
 Ignore the first line which will be your own router.  What you want to see is if any of the next 3 or 4 lines start with 10., 192. or 172.  If the first number is a 172 we need to check the second number to see if it's between 16 to 31.  If any of these returned lines matches this you are likely being blocked by your ISP.
+
+If the [canyouseeme.org](http://www.canyouseeme.org) test works but the device is still failing to sign in to the server, check that you have allowed remote connections for the user.
+
+### Allow Remote Access for users
+
+A setting is available for user accounts to allow or disallow remote connections. Edit the user settings and tick the **"Allow remote connections to this Emby Server"** to allow remote connections for a specific user account. Refer to [Users](Users.md) Settings. 
+
+![](images/server/users18.png)


### PR DESCRIPTION
Following further feedback from user cptbrainia here https://emby.media/community/index.php?/topic/130162-unable-to-log-into-emby-server-via-vpn/#comment-1369214, I have made further changes

The Advanced-Menu and Connectivity articles remain to be identical.

I moved the reference to Emby Connect to the end of the connectivity articles,

I took the opportunity to cover Double NAT and multiple emby servers and need to have different public port if more than one server. Also I added the cgNAT range.

I am not sure why the link to Remote-Setup was going to https://github.com/EmbySupport/Emby.Docs/blob/master/Remote-Setup.md rather than just [Remote-Setup](Remote-Setup.md] - i changed it to that - if there is a reason why it can't be that then would need to change it back

If you are not happy about including the extra bits about different public port, multiple servers, multiple routers and double NAT then I would be happy to put back the text as it was and add a separate advanced remote setup article.