### PR TITLE
change downloads & sync title to Introduction

### DIFF
--- a/Sync-Introduction.md
+++ b/Sync-Introduction.md
@@ -1,6 +1,6 @@
 ---
 uid: Sync-Introduction
-title: Downloads & Sync
+title: Introduction
 legacyUrl: /support/solutions/articles/44001161893-sync-introduction
 ---
 

--- a/toc.yml
+++ b/toc.yml
@@ -247,9 +247,9 @@
     href: Devices.md
   - name: Camera Upload
     href: Camera-Upload.md
-  - name: Download & Sync
+  - name: Downloads & Sync
     items:
-    - name: Downloads & Sync
+    - name: Introduction
       href: Sync-Introduction.md
     - name: Download Options
       href: Sync.md


### PR DESCRIPTION
It does not look right that the group of articles title is the same as the first article title - so changing first document title

![image](https://github.com/user-attachments/assets/86f7a3ba-39b2-424b-b40a-fb6e71b4fb2b)

Also for consistency with links from other articles changed the group name from "Download & Sync" to "Downloads & Sync"