### PR TITLE
Mention the cap of 8 versions for media items

### DIFF
--- a/3D-Videos.md
+++ b/3D-Videos.md
@@ -68,3 +68,6 @@ Here's an example of a movie containing multiple versions in a single movie fold
     /300 (2006) - 3d.mvc.mp4
 
 ```
+
+> [!NOTE]
+> There is a limit on the number of different versions for a media item. Up to 8 different versions will appear in any list of media item versions.

--- a/Folder-Sync.md
+++ b/Folder-Sync.md
@@ -47,3 +47,6 @@ Once synced, Emby apps will automatically use the additional media sources when 
 In this example, folder sync was used to create mobile 4Mbps versions of some media. They are available as alternative versions in playback and in this example this version was pre-selected automatically.
 
 ![](images/plugins/foldersync7.png) 
+
+> [!NOTE]
+> There is a limit on the number of different versions for a media item. Up to 8 different versions will appear in any list of media item versions.

--- a/Movie-Naming.md
+++ b/Movie-Naming.md
@@ -90,6 +90,9 @@ If using the dash method anything following the dash will be what you see in the
 > [!NOTE]
 > The above example includes a 3D version, which is discussed in the [3D Video](3D-Videos.md) naming guide.  Also, this feature is primarily designed for multiple qualities of the same item.  It can be used for different "cuts" but there may be some limitations in doing that.
 
+> [!NOTE]
+> There is a limit on the number of different versions for a media item. Up to 8 different versions will appear in a list of a movie versions.
+
 ## Movie extras
 
 Special features for movies can be stored as video files in an extras folder under movie folders. Nested folders are not supported. 

--- a/TV-Naming.md
+++ b/TV-Naming.md
@@ -228,6 +228,8 @@ Star Trek, The Next Generation - S01E01 - Digital Remix.mkv
 
 anything following the "-" (dash) up to the file extension will be used in the drop down version selector in your Emby client. In this case the two versions show in the interface will be "Original Broadcast" & "Digital Remix".
 
+> [!NOTE]
+> There is a limit on the number of different versions for a media item. Up to 8 different versions will appear in a list of an episode versions.
 
 ## Multi-Episode files
 


### PR DESCRIPTION
This follows from discussion in this topic https://emby.media/community/index.php?/topic/132614-multiple-versions-of-the-same-movie-showing-up-in-library-view/

Note that this will need to change if the cap becomes a server setting