### PR TITLE
Correct Folder Sync access rights mentions

### DIFF
--- a/Folder-Sync.md
+++ b/Folder-Sync.md
@@ -20,7 +20,7 @@ Restart Emby Server to complete the plugin installation.
 
 Decide what type of sync folders you will want to have. Examples would be sync folders containing media converted to specific resolution eg 4Mb for streaming to mobile devices or a folder to hold archived copies of the media at original resolution. These destination sync folders can be local disc drives or network shares. The **Download to...** button, available within the media and libraries context menus, becomes the mechanism to create the synced media files in these folder paths. 
 
-Each Folder Sync plugin sync folder path will need to have a name assigned. This name will appear to users that have been given access. Choose naming that will make it clear to users what it is. The name will be visible when selecting media for playback and also on the **Download to...** menus. 
+Each sync folder path will need to have a name assigned. Choose naming that will make it clear to users what it is. The name will be visible when selecting media for playback and also on the **Download to...** menus for users that have been granted access to create Folder Sync jobs.
 
 Click on **Folders** **+ Add** button
 
@@ -30,7 +30,7 @@ Enter the path and the display name.
 
 ![](images/plugins/foldersync3.png)
 
-You can also choose whether or not to limit the sync folder access to specific users.
+Untick the **Grant access to all users** to specify which user account(s) will be allowed to create Folder Sync jobs that will write to this folder.
 
 ![](images/plugins/foldersync4.png) 
 

--- a/Sync-Introduction.md
+++ b/Sync-Introduction.md
@@ -12,6 +12,6 @@ Depending on user access rights and the media type, different options for downlo
 
 A popular use of Downlads, is picking a few movies or TV Shows and download this content to a mobile device. This allows them to then playback this media "off line". See [Offline Access](Offline-Access.md).
 
-When using [Folder Sync](Folder-Sync.md), the media that is copied to the target folder would appear as alternative versions to the original media file for users that were granted access.
+When using [Folder Sync](Folder-Sync.md), the media that is copied to the target folder would appear as alternative versions to the original media file.
 
 Emby Server admin users have overall control of all download and synced media for all devices and all users.


### PR DESCRIPTION
Found out from [here](https://github.com/MediaBrowser/issues/issues/63#issuecomment-2462650501) that the access rights only relate to creation of Folder Sync jobs. Adjusting the text to take this into account