### PR TITLE
Update to include seasonxx- prefixed files

### DIFF
--- a/TV-Naming.md
+++ b/TV-Naming.md
@@ -323,6 +323,9 @@ For backdrops, X represents a number, and you can have any amount of numbered ba
 
 ```
 
+> [!NOTE]
+> The syntax supported for season images when there are no season folders, as shown below, is also accepted when season folders are in use. When using the "seasonXX-" or "season-specials-" prefix syntax, place these files in the root folder for the series.
+
 ## Season images without season folder
 
 If season folders are not used, season images can still be supplied directly in the series folder, using a naming convention to indicate the season.


### PR DESCRIPTION
Follows from this forum [post](https://emby.media/community/index.php?/topic/133779-meta-data-labeling/#findComment-1401476) and discussion 

The "seasonXX-" prefix in the root folder of the series works whether there are season folders in use or not

This adds a note to indicate this