### PR TITLE
changes to trailers and naming documents

### DIFF
--- a/Movie-Naming.md
+++ b/Movie-Naming.md
@@ -67,7 +67,7 @@ tmdbid (https://www.themoviedb.org/)
 imdbid (https://www.imdb.com/)
 
 tvdbid (https://thetvdb.com/)
-Note:  tmdbid is the preferred tag to use for most uses
+
 
 ## Multi-version movies
  

--- a/TV-Naming.md
+++ b/TV-Naming.md
@@ -58,9 +58,6 @@ Emby supports the following tags with the host website for lookup.
 
 
 
-Note:  tmdbid is the preferred tag to use for most uses
-
-
 ## Complex Folder Structure
 
 In more complex situations where your top-level directory is further sub-divided before the show folders, the recommended option is to create a TV media folder and add the sub-folder locations instead of the top level folder. 
@@ -252,9 +249,7 @@ The following conventions are supported:
 * show name S01E02E03 episode name.ext
 * show name S01xE02xE03 episode name.ext
 * show name S01E02-E03 episode name.ext
-* show name S01E02-E05 episode name.ext
 * show name S01E02-X03 episode name.ext
-* show name S01E02-X05 episode name.ext
 * show name 01x02 01x03 episode name.ext
 * show name 01x02 - 01x03 episode name.ext
 * show name 01x02 - x03 episode name.ext
@@ -280,7 +275,7 @@ For example:
 ```
 
 > [!TIP]
-> Please see Ordering TV Show Special/Extras to learn how to place these specials in the proper timeline.
+> Please see [Ordering TV Show Special/Extras](Ordering-TV-Specials.md) to learn how to place these specials in the proper timeline.
 
 ## Series & Season Images
 

--- a/Trailers.md
+++ b/Trailers.md
@@ -20,7 +20,7 @@ Alternatively, trailers can also be stored in a trailers sub-folder. Bluray and 
    /Home Alone (1990)
      /VIDEO_TS
      /trailers
-         trailer.mkv
+       trailer.mkv
 ```
 
 ## Trailer for TV Shows
@@ -29,10 +29,9 @@ A trailers subfolder should be placed underneath the series folder, or any seaso
 
 ```
 /TV Shows
-   /Home Alone (1990)
-     /My Show (2020)
-     /trailers
-         trailer.mkv
+  /My Show (2020)
+    /trailers
+      trailer.mkv
 ```
 
 ## Trailer Plugins of Interest


### PR DESCRIPTION
This follows from feedback from user Fsweep in this forum topic https://emby.media/community/index.php?/topic/139668-minor-kb-update-suggestions/

Changes are:
- remove mention that tmdbid is our preferred id to add in media file/folder  names
- remove erroneous movie example in TV shows trailers section
- remove redundant examples in tv naming
- add link to ordering specials article for TV shows