### PR TITLE
remove references to Emby Theater in Docs

### DIFF
--- a/Hardware-Acceleration-Overview.md
+++ b/Hardware-Acceleration-Overview.md
@@ -56,6 +56,6 @@ OpenMax is an API specification covering various aspects of media acceleration. 
 In many cases these subtitle formats will need to be burned into the video on the fly with transcoding. Most GPUs do not support this and as a result there will be some significant CPU involvement. This is a very taxing process for even a powerful server, and it's generally something you want to avoid. Here are the best ways to avoid burning in subtitles:
 - Turn off the subtitles prior to playback using the pre-playback subtitle selection menu
 - Use external text-based subtitles instead, such as .srt files. Emby Server's subtitle download features can help automate the process of acquiring these.
-- Use an Emby app that can direct play these subtitle formats without transcoding, such as Emby Windows, Emby Theater for Linux & Mac, Android, or iOS.
+- Use an Emby app that can direct play these subtitle formats without transcoding, such as Emby Windows, Emby Linux, Emby for MacOS, Android, or iOS.
 
 - If you are using Windows with Remote Desktop and have trouble getting hardware acceleration please read [this article](Hwa-Fails-with-RDP.md).

--- a/Keyboard-and-Remote-Support.md
+++ b/Keyboard-and-Remote-Support.md
@@ -8,8 +8,7 @@ This document applies to the following apps:
 
 * Emby Web app
 * Emby Windows
-* Emby Theater for Raspberry Pi
-* Emby Theater for Linux
+* Emby Linux
 * Emby for Samsung Tizen
 * Emby for Xbox One
 * Emby for Sony PS4

--- a/Premiere-Feature-Matrix.md
+++ b/Premiere-Feature-Matrix.md
@@ -377,7 +377,52 @@ legacyUrl: /support/solutions/articles/44001173099-emby-premiere-feature-matrix
     </tbody>
 </table>
 
-## Linux or MacOS (Emby Theater)
+## Emby Linux
+
+<table class="premiere-matrix-table">
+    <thead>
+    <tr>
+        <th>Feature</th>
+        <th>Free</th>
+        <th></th>
+        <th>
+            <span>Premiere</span>
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>Limited Playback (one-minute only)</td>
+        <td>
+            <div>✔</div>
+        </td>
+        <td></td>
+        <td>
+            <div>✔</div>
+        </td>
+    </tr>
+    <tr>
+        <td>Full Playback</td>
+        <td>
+            <div></div>
+        </td>
+        <td></td>
+        <td>
+            <div>✔</div>
+        </td>
+    </tr>
+    <tr>
+        <td>Live TV</td>
+        <td></td>
+        <td></td>
+        <td>
+            <div>✔</div>
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+## Emby for MacOS
 
 <table class="premiere-matrix-table">
     <thead>


### PR DESCRIPTION
- Mention of Emby Theater apps for direct play of PGS subtitles on Mac and Linux
- Keyboard mapping
- feature matrix